### PR TITLE
500/jongho/click highlight

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,1 @@
+@import url('https://fonts.googleapis.com/css2?family=Libre+Caslon+Display&display=swap');

--- a/src/components/EpubViewerPage/EpubViewer.css
+++ b/src/components/EpubViewerPage/EpubViewer.css
@@ -8,6 +8,7 @@
     justify-content: space-between;
 }
 
-/* ::selection {
-    background: yellow;
-  } */
+
+#epubViewer svg{
+    opacity: 0.3;
+}

--- a/src/components/EpubViewerPage/EpubViewer.js
+++ b/src/components/EpubViewerPage/EpubViewer.js
@@ -30,11 +30,11 @@ class EpubViewer extends Component {
     this.rendition = null;
   }
 
-  getAnnoData = async () => {
-      let book_id = this.props.id;
-      const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + book_id+ "/public");
-      return annos.data;
-  }
+  // getAnnoData = async () => {
+  //     let book_id = this.props.id;
+  //     const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + book_id+ "/public");
+  //     return annos.data;
+  // }
   
   getRendition = rendition => {
     // Set inital font-size, and add a pointer to rendition for later updates
@@ -87,7 +87,7 @@ class EpubViewer extends Component {
           text = range.toString();
           this.setState({high_text: text});
 
-          let res = await axios({
+          await axios({
             method: 'post',
             url: process.env.REACT_APP_RENOSH_BASE_URL + 'api/highlights/book/' + this.props.id,
             data: {
@@ -96,12 +96,14 @@ class EpubViewer extends Component {
               location: cfiRange,
               text
             }
+          }).then(res => {
+            this.setState ({high_id:res.data.highlight_id});
+            this.props.updateAnnoList("UPDATE_HIGHLIGHT", this.state.high_id, this.state.high_text);
+  
+            if(!this.state.isPanelOpen)
+              this.handlePanelOpen();
           })
-          this.setState ({high_id:res.data.highlight_id});
-          this.props.updateAnnoList("UPDATE_HIGHLIGHT", this.state.high_id, this.state.high_text);
-
-          if(!this.state.isPanelOpen)
-            this.handlePanelOpen();
+          
         }
       }.bind(this))
     }.bind(this));

--- a/src/components/InfoPage/Info.jsx
+++ b/src/components/InfoPage/Info.jsx
@@ -1,44 +1,60 @@
 import React, { Component } from 'react';
-// import {Link} from 'react-router-dom';
 import InfoData from './InfoData'
 import axios from 'axios'
+const CancelToken = axios.CancelToken;
+const source = CancelToken.source();
 
 export default class Info2 extends Component {
     state = {
         book: {},
-        isLoading : true
+        isLoading : true,
+        isUnmount: false
     }       
 
     getBookInfoDataFromServer = async (book_id) => {
-        const book = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL + "api/books/" + book_id);        
-
-        this.setState({
-            book: book.data,
-            isLoading: false
+        await axios.get(process.env.REACT_APP_RENOSH_BASE_URL + "api/books/" + book_id, {
+            cancelToken: source.token
         })
+        .then(res =>{
+            console.log("this is isUnmount = ", this.state.isUnmount)
+            if(!this.state.isUnmount){
+                console.log("받아옴")
+                this.setState({
+                    book: res.data,
+                    isLoading: false
+                })
+            }
+        }).catch(err => {
+            console.log(err)
+        });
     }   
 
     componentDidMount() {
+        // URL을 통한 website접근일 경우
+        // this.setState({
+        //     isUnmount: false
+        // })
         if(this.props.book_id === undefined || this.props.book_id === null) {
             let book_id = this.props.match.params.book_id;
-            this.getBookInfoDataFromServer(book_id);            
-            this.setState({
-                isLoading:false
-            })
+            this.getBookInfoDataFromServer(book_id);
         } else {
             this.setState({
                 isLoading:false
             })
         }
     }
-
-    
-
+    componentWillUnmount(){
+        // source.cancel('Operation canceled by the user.');
+        this.setState({
+            isUnmount: true
+        }, console.log("언마운트 됨", this.state.isUnmount))
+        
+    }
     render() {
         let infoData;
-        if(!this.state.isLoading && this.state.book !== {}) {
+        if(!this.state.isLoading) {
             infoData = <InfoData image={this.state.book.image} title={this.state.book.title} summary={this.state.book.summary} />
-        }else if(!this.state.isLoading) {
+        }else {
             infoData = <InfoData image={this.props.image} title={this.props.title} summary={this.props.summary} />
         }
         return (

--- a/src/components/InfoPage/Info.jsx
+++ b/src/components/InfoPage/Info.jsx
@@ -1,24 +1,21 @@
 import React, { Component } from 'react';
 import InfoData from './InfoData'
 import axios from 'axios'
-const CancelToken = axios.CancelToken;
-const source = CancelToken.source();
+
+// axios비동기 요청시 언마운트가 진행되고 나서 setState()요청이 있을 수 있다.(예를 들어 페이지를 빠르게 이동했는데, axios요청이 진행한 경우,)
+// 이때 간단히 글로별 변수를 만들어서 컴포넌트가 언마운트 될 때(componentWillUnmount()) 변수의 값을 바꾸는 방식으로 setState를 검사할 수 있다.
+let isUnmount = false; 
 
 export default class Info2 extends Component {
     state = {
         book: {},
         isLoading : true,
-        isUnmount: false
     }       
 
     getBookInfoDataFromServer = async (book_id) => {
-        await axios.get(process.env.REACT_APP_RENOSH_BASE_URL + "api/books/" + book_id, {
-            cancelToken: source.token
-        })
+        await axios.get(process.env.REACT_APP_RENOSH_BASE_URL + "api/books/" + book_id)
         .then(res =>{
-            console.log("this is isUnmount = ", this.state.isUnmount)
-            if(!this.state.isUnmount){
-                console.log("받아옴")
+            if(!isUnmount){
                 this.setState({
                     book: res.data,
                     isLoading: false
@@ -31,9 +28,7 @@ export default class Info2 extends Component {
 
     componentDidMount() {
         // URL을 통한 website접근일 경우
-        // this.setState({
-        //     isUnmount: false
-        // })
+        isUnmount = false
         if(this.props.book_id === undefined || this.props.book_id === null) {
             let book_id = this.props.match.params.book_id;
             this.getBookInfoDataFromServer(book_id);
@@ -44,11 +39,7 @@ export default class Info2 extends Component {
         }
     }
     componentWillUnmount(){
-        // source.cancel('Operation canceled by the user.');
-        this.setState({
-            isUnmount: true
-        }, console.log("언마운트 됨", this.state.isUnmount))
-        
+        isUnmount = true;
     }
     render() {
         let infoData;

--- a/src/components/ListPage/Book.js
+++ b/src/components/ListPage/Book.js
@@ -8,7 +8,7 @@ class Book extends Component {
 
     getAnnoData = async () => {
         let book_id = this.props.id;  
-        const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + book_id);
+        const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + book_id+ "/public");
         return annos.data;
     }
 

--- a/src/components/ListPage/DashBoard.css
+++ b/src/components/ListPage/DashBoard.css
@@ -1,5 +1,5 @@
 #dash_div {
-    width: 1920px;
+    width: 100%;
     height: 185px;
     border: solid 1px #707070;
     background-color: #2b335b;

--- a/src/components/ListPage/DashBoard.css
+++ b/src/components/ListPage/DashBoard.css
@@ -9,7 +9,7 @@
     /* width: 7.5%;
     height: 30.8%; */
     padding: 3.3rem 4.3rem 0rem 4.3rem;
-    font-family: Arial;
+    font-family: 'Libre Caslon Display', serif;
     font-size: 48px;
     font-weight: bold;
     font-stretch: normal;

--- a/src/components/ListPage/ListForm.js
+++ b/src/components/ListPage/ListForm.js
@@ -8,16 +8,12 @@ class ListForm extends Component {
         return(
             <div id="listForm">
                 <div id="searchDiv">
-                    {/* <img src="../../../images/magnifying-glass.png" alt="glassImage"></img>
-                    <input id="search" name="search" placeholder="search: " />
-                    <button id="searchBtn" >search</button> */}
                 </div>
 
                 <div id="myPage">
                     <Link to={'myPage'}>MyPage</Link>
                 </div>
                 <LoginButton/>
-                {/* <button id="addBtn" >+</button> */}
             </div>
         )
     }

--- a/src/components/PanelPage/AnnoBody.js
+++ b/src/components/PanelPage/AnnoBody.js
@@ -13,7 +13,6 @@ class AnnoBody extends Component {
         }else
             annos = null;
             
-        debugger
         return annos.data;
     }
     handleMemoSubmit =  async (e) => {

--- a/src/components/PanelPage/AnnoBody.js
+++ b/src/components/PanelPage/AnnoBody.js
@@ -4,13 +4,22 @@ import SelectAnnoListArrangeContainer from '../../containers/PanelPage/SelectAnn
 import axios from 'axios';
 
 class AnnoBody extends Component {
-    getAnnoData = async () => {
-        const annos = await axios.get("https://renosh-server.azurewebsites.net/api/highlights/book/" + this.props.book_id);
+    getAnnoData = async (mode) => {        
+        let annos;
+        if (mode === 'private' && this.props.user_id !== null){
+            annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/users/"+this.props.user_id+"/books/"+this.props.book_id+"/highlights");
+        }else if(mode === 'others' || (this.props.user_id === null && mode === 'private')){
+            annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + this.props.book_id+ "/public");
+        }else
+            annos = null;
+            
+        debugger
         return annos.data;
     }
     handleMemoSubmit =  async (e) => {
         e.preventDefault(); // 페이지 리로딩 방지
         e.persist(); // 비동기적으로 이벤트 속성을 참조하고 싶을 때
+        let annoList;
         let isPublickChecked = e.target.form.elements[1].checked;
         if(!isPublickChecked){
             await axios({
@@ -21,6 +30,7 @@ class AnnoBody extends Component {
                     scope: 'private'
                 }
             });
+            annoList = await this.getAnnoData('private'); 
         } else {
             await axios({                
                 method:'put',
@@ -30,10 +40,11 @@ class AnnoBody extends Component {
                     scope: 'public'
                 }
             });
+            annoList = await this.getAnnoData('others');
         }
 
         // 바뀐 내용이 바로 rendering될 수 있도록 annoList의 내용을 업데이트 해준다.
-        let annoList = await this.getAnnoData(); 
+        
         this.props.updateAnnoList("UPDATE_ANNOLIST", annoList);
 
         // 기존의 값들을 초기화 해준다.
@@ -55,7 +66,7 @@ class AnnoBody extends Component {
                     <button id="saveAnno" onClick={this.handleMemoSubmit.bind(this)}>Save</button>
                 </form>  
                 <SelectAnnoListArrangeContainer />      
-                <AnnoListContainder changeLocation={this.props.changeLocation} />   
+                <AnnoListContainder changeLocation={this.props.changeLocation} findAnno={this.props.findAnno} />   
             </div>
         )
     }

--- a/src/components/PanelPage/AnnoBody.js
+++ b/src/components/PanelPage/AnnoBody.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import AnnoListContainder from '../../containers/PanelPage/AnnoList';
+import SelectAnnoListArrangeContainer from '../../containers/PanelPage/SelectAnnoListArrange'
 import axios from 'axios';
 
 class AnnoBody extends Component {
@@ -41,12 +42,7 @@ class AnnoBody extends Component {
                     <input type="checkbox" name="Private" />Private
                     <button id="saveAnno" onClick={this.handleMemoSubmit.bind(this)}>Save</button>
                 </form>  
-                <br></br>          
-                <div className="switch">
-                    <input type="checkbox"  ></input>Others AnnoTation Show
-                    {/* (나중에 radio든 select든 해서 그룹별로, 아니면 내꺼만 으로 선택할 수 있게 바꾸자) */}
-                    <span className="slider"></span>
-                </div>           
+                <SelectAnnoListArrangeContainer />      
                 <AnnoListContainder changeLocation={this.props.changeLocation} />   
             </div>
         )

--- a/src/components/PanelPage/AnnoBody.js
+++ b/src/components/PanelPage/AnnoBody.js
@@ -11,14 +11,26 @@ class AnnoBody extends Component {
     handleMemoSubmit =  async (e) => {
         e.preventDefault(); // 페이지 리로딩 방지
         e.persist(); // 비동기적으로 이벤트 속성을 참조하고 싶을 때
-
-        await axios({
-            method:'put',
-            url: process.env.REACT_APP_RENOSH_BASE_URL + "api/highlights/"+this.props.book_id+ "/"+this.props.high_id,
-            data:{
-                memo: e.target.form.elements[0].value
-            }
-        });    
+        let isPublickChecked = e.target.form.elements[1].checked;
+        if(!isPublickChecked){
+            await axios({
+                method:'put',
+                url: process.env.REACT_APP_RENOSH_BASE_URL + "api/highlights/"+this.props.book_id+ "/"+this.props.high_id,
+                data:{
+                    memo: e.target.form.elements[0].value,
+                    scope: 'private'
+                }
+            });
+        } else {
+            await axios({                
+                method:'put',
+                url: process.env.REACT_APP_RENOSH_BASE_URL + "api/highlights/"+this.props.book_id+ "/"+this.props.high_id,
+                data:{
+                    memo: e.target.form.elements[0].value,
+                    scope: 'public'
+                }
+            });
+        }
 
         // 바뀐 내용이 바로 rendering될 수 있도록 annoList의 내용을 업데이트 해준다.
         let annoList = await this.getAnnoData(); 
@@ -39,7 +51,7 @@ class AnnoBody extends Component {
                     {high_text}
                     <input id="inputAnno" 
                         name="inputAnno" placeholder="content" autoFocus/>
-                    <input type="checkbox" name="Private" />Private
+                    <input type="checkbox" name="isPublic" />Public
                     <button id="saveAnno" onClick={this.handleMemoSubmit.bind(this)}>Save</button>
                 </form>  
                 <SelectAnnoListArrangeContainer />      

--- a/src/components/PanelPage/Panel.js
+++ b/src/components/PanelPage/Panel.js
@@ -1,16 +1,20 @@
 import React, {Component} from 'react';
 import BookBriefInfoContainer from '../../containers/PanelPage/BookBriefInfo'
-// import AnnoBody from './AnnoBody';
 import AnnoBodyContainer from '../../containers/PanelPage/AnnoBody'
 import './Panel.css'
 
 
 class Panel extends Component {
+    findAnno() {
+        let scroll = this.refs.scrollElement || document.getElementById('scrollElement');
+        scroll.scrollTop = 2000;
+    }
     render() {
+        
         return(
-            <div id="panel">                
+            <div id="panel" ref="scrollElement" >
                 <BookBriefInfoContainer /> 
-                <AnnoBodyContainer changeLocation={this.props.changeLocation} />                
+                <AnnoBodyContainer changeLocation={this.props.changeLocation} findAnno={this.findAnno}/>                
             </div>
         )
     }

--- a/src/components/PanelPage/Panel.js
+++ b/src/components/PanelPage/Panel.js
@@ -9,8 +9,8 @@ class Panel extends Component {
     render() {
         return(
             <div id="panel">                
-                <BookBriefInfoContainer />                
-                <AnnoBodyContainer changeLocation={this.props.changeLocation} />
+                <BookBriefInfoContainer /> 
+                <AnnoBodyContainer changeLocation={this.props.changeLocation} />                
             </div>
         )
     }

--- a/src/components/PanelPage/SelectAnnoListArrange.css
+++ b/src/components/PanelPage/SelectAnnoListArrange.css
@@ -1,0 +1,27 @@
+#select-annoList-arrange {
+    margin: 10px;    
+    padding: 10px;
+    border: 2px solid gray;
+}
+
+#arrange-show {
+    font-family: Verdana, Geneva, Tahoma, sans-serif;
+    padding: 5px;
+}
+
+#arrange-display {
+    font-family: Verdana, Geneva, Tahoma, sans-serif;
+    padding: 5px;
+}
+
+#arrange-show-title {
+    font-family: Georgia, 'Times New Roman', Times, serif;
+}
+
+#arrange-display-title {
+    font-family: Georgia, 'Times New Roman', Times, serif;
+}
+
+#if_team_checked {
+    visibility: hidden;
+}

--- a/src/components/PanelPage/SelectAnnoListArrange.jsx
+++ b/src/components/PanelPage/SelectAnnoListArrange.jsx
@@ -6,13 +6,10 @@ export default class SelectAnnoListArrange extends Component {
     getAnnoData = async (viewMode) => {
         let book_id = this.props.id;  
         if(viewMode === 'private' && this.props.user_id !== null) {
-            const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/users/"+this.props.user_id+"/highlights");
+            const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/users/"+this.props.user_id+"/books/"+book_id+"/highlights");
             return annos.data;
-        }else if(viewMode === 'private' && this.props.user_id === null) {
-            const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + book_id);
-            return annos.data;
-        }else if(viewMode === 'others') {
-            const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + book_id);
+        }else if(viewMode === 'others' || (this.props.user_id === null && viewMode === 'private')) {
+            const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + book_id+ "/public");
             return annos.data;
         }
         else {
@@ -36,7 +33,7 @@ export default class SelectAnnoListArrange extends Component {
                             let annoList = await this.getAnnoData(viewMode); 
                             this.props.changeViweMode("CHANGE_VIEW_MODE", annoList)
                         }} name="arrange-display" value="private" />
-                        <label>Private</label>
+                        <label>Mine</label>
 
                         <input type="radio" id="others" onClick={async () => {
                             let viewMode = 'others'

--- a/src/components/PanelPage/SelectAnnoListArrange.jsx
+++ b/src/components/PanelPage/SelectAnnoListArrange.jsx
@@ -1,0 +1,52 @@
+import React, { Component } from 'react'
+import "./SelectAnnoListArrange.css"
+import axios from 'axios'
+
+export default class SelectAnnoListArrange extends Component {
+    getAnnoData = async (viewMode) => {
+        let book_id = this.props.id;  
+        if(viewMode === 'private') {
+            console.log("viewMode? : ", viewMode)
+            const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/users/"+this.props.user_id+"/highlights");
+            return annos.data;
+        } else if(viewMode === 'others') {
+            console.log("viewMode? : ", viewMode)
+            const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + book_id);
+            return annos.data;
+        }
+        else {
+            console.log("viewMode? : ", viewMode)
+            return null;
+        }
+    }
+    render() {
+        return (
+            <div id="select-annoList-arrange">
+                    <div id="arrange-show">
+                        <label id="arrange-show-title">Exposure range: </label>
+                        <input type="radio" id="private" name="arrange-show" value="private" />
+                        <label>Private</label>                        
+                        <input type="radio" id="others" name="arrange-show" value="others" />
+                        <label>Others</label>
+                    </div>
+                    <div id="arrange-display">
+                        <label id="arrange-display-title">Viewing range: </label>
+                        <input type="radio" id="private" onClick={async () => {
+                            // 여기서 axios요청을 하고 결과값을 스토어에 저장한다.
+                            let viewMode = 'private'
+                            let annoList = await this.getAnnoData(viewMode); 
+                            this.props.changeViweMode("CHANGE_VIEW_MODE", annoList)
+                        }} name="arrange-display" value="private" />
+                        <label>Private</label>
+
+                        <input type="radio" id="others" onClick={async () => {
+                            let viewMode = 'others'
+                            let annoList = await this.getAnnoData(viewMode); 
+                            this.props.changeViweMode("CHANGE_VIEW_MODE", annoList)
+                        }} name="arrange-display" value="others" />
+                        <label>Others</label>
+                    </div>
+                </div>
+        )
+    }
+}

--- a/src/components/PanelPage/SelectAnnoListArrange.jsx
+++ b/src/components/PanelPage/SelectAnnoListArrange.jsx
@@ -5,34 +5,33 @@ import axios from 'axios'
 export default class SelectAnnoListArrange extends Component {
     getAnnoData = async (viewMode) => {
         let book_id = this.props.id;  
-        if(viewMode === 'private') {
-            console.log("viewMode? : ", viewMode)
+        if(viewMode === 'private' && this.props.user_id !== null) {
             const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/users/"+this.props.user_id+"/highlights");
             return annos.data;
-        } else if(viewMode === 'others') {
-            console.log("viewMode? : ", viewMode)
+        }else if(viewMode === 'private' && this.props.user_id === null) {
+            const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + book_id);
+            return annos.data;
+        }else if(viewMode === 'others') {
             const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + book_id);
             return annos.data;
         }
         else {
-            console.log("viewMode? : ", viewMode)
             return null;
         }
     }
     render() {
         return (
             <div id="select-annoList-arrange">
-                    <div id="arrange-show">
+                    {/* <div id="arrange-show">
                         <label id="arrange-show-title">Exposure range: </label>
                         <input type="radio" id="private" name="arrange-show" value="private" />
                         <label>Private</label>                        
                         <input type="radio" id="others" name="arrange-show" value="others" />
                         <label>Others</label>
-                    </div>
+                    </div> */}
                     <div id="arrange-display">
                         <label id="arrange-display-title">Viewing range: </label>
                         <input type="radio" id="private" onClick={async () => {
-                            // 여기서 axios요청을 하고 결과값을 스토어에 저장한다.
                             let viewMode = 'private'
                             let annoList = await this.getAnnoData(viewMode); 
                             this.props.changeViweMode("CHANGE_VIEW_MODE", annoList)

--- a/src/components/PanelPage/SelectAnnoListArrange.jsx
+++ b/src/components/PanelPage/SelectAnnoListArrange.jsx
@@ -19,27 +19,20 @@ export default class SelectAnnoListArrange extends Component {
     render() {
         return (
             <div id="select-annoList-arrange">
-                    {/* <div id="arrange-show">
-                        <label id="arrange-show-title">Exposure range: </label>
-                        <input type="radio" id="private" name="arrange-show" value="private" />
-                        <label>Private</label>                        
-                        <input type="radio" id="others" name="arrange-show" value="others" />
-                        <label>Others</label>
-                    </div> */}
                     <div id="arrange-display">
                         <label id="arrange-display-title">Viewing range: </label>
                         <input type="radio" id="private" onClick={async () => {
                             let viewMode = 'private'
                             let annoList = await this.getAnnoData(viewMode); 
                             this.props.changeViweMode("CHANGE_VIEW_MODE", annoList)
-                        }} name="arrange-display" value="private" />
+                        }} name="arrange-display" value="private"  />
                         <label>Mine</label>
 
                         <input type="radio" id="others" onClick={async () => {
                             let viewMode = 'others'
                             let annoList = await this.getAnnoData(viewMode); 
                             this.props.changeViweMode("CHANGE_VIEW_MODE", annoList)
-                        }} name="arrange-display" value="others" />
+                        }} name="arrange-display" value="others" defaultChecked />
                         <label>Others</label>
                     </div>
                 </div>

--- a/src/containers/PanelPage/AnnoBody.jsx
+++ b/src/containers/PanelPage/AnnoBody.jsx
@@ -3,10 +3,15 @@ import AnnoBody from "../../components/PanelPage/AnnoBody";
 
 export default connect(
     function(state) {
+        let user_id; 
+        if(state.account == null) {
+            user_id = null
+        } else user_id = state.account.accountIdentifier
         return {
             book_id: state.selected_book_id,
             high_id: state.selected_high_id,
-            high_text: state.selected_high_text
+            high_text: state.selected_high_text,
+            user_id
         }
     },
     function(dispatch) {

--- a/src/containers/PanelPage/SelectAnnoListArrange.jsx
+++ b/src/containers/PanelPage/SelectAnnoListArrange.jsx
@@ -3,10 +3,13 @@ import SelectAnnoListArrange from "../../components/PanelPage/SelectAnnoListArra
 
 export default connect(
     function(state){
-        debugger;
+        let user_id; 
+        if(state.account == null) {
+            user_id = null
+        } else user_id = state.account.accountIdentifier
         return{
             id: state.selected_book_id,
-            user_id: state.account.accountIdentifier
+            user_id
         }
     },
     function(dispatch) {

--- a/src/containers/PanelPage/SelectAnnoListArrange.jsx
+++ b/src/containers/PanelPage/SelectAnnoListArrange.jsx
@@ -1,0 +1,22 @@
+import { connect } from "react-redux";
+import SelectAnnoListArrange from "../../components/PanelPage/SelectAnnoListArrange";
+
+export default connect(
+    function(state){
+        debugger;
+        return{
+            id: state.selected_book_id,
+            user_id: state.account.accountIdentifier
+        }
+    },
+    function(dispatch) {
+        return {
+            changeViweMode: function(mode, annoList) {
+                dispatch({
+                    type: mode,
+                    annoList
+                })
+            }
+        }
+    }
+)(SelectAnnoListArrange);

--- a/src/store.js
+++ b/src/store.js
@@ -52,6 +52,8 @@ function reducer(state=initState, action) {
             return {...state, selected_high_id: '', selected_high_text: ''}
         case 'UPDATE_ANNOLIST':
             return {...state,  selected_annoList: action.annoList}
+        case 'CHANGE_VIEW_MODE':
+            return {...state,  selected_annoList: action.annoList}
         case AuthenticationActions.Initializing:
             return {
                 ...state,


### PR DESCRIPTION
src/App.css
"Renosh"에 font 적용하기 위한 변경

src/components/EpubViewerPage/EpubViewer.css
하이라이트가 여러번 중첩되는 기능을 막아버린것

src/components/EpubViewerPage/EpubViewer.js
32~37 -> 처음에 책에대한 anno목록을 가져올 때, 그 책에서 public(공용)으로 가져오기
(annotation은 scope라는 속성이 있는데, private은 개인의 것만, public은 모든 사람이 볼 수 잇는 범위입니다.)

53~57, 64,~67 -> hilight(= anno)의 색상과 투명도를 변경할 수 잇는 부분입니다. 
53 -> ( rendition.annotations.add("highlight", cfiRange, {"id":anno.id}, (e)=>{)
에서 {"id": anno.id}는 viewer에 highlight에도 DB에 저장된 anno.id를 저장할 수 있는 방법입니다.
이를 통해서 추후에 클릭했을때 이벤트 등을 추가할 수 있습니다.

53~ 56-> rendition.annotations.add("highlight", cfiRange, {"id":anno.id}, (e)=>{
              // 현재 패널이 열리는 옵션에 대해 수정이 필요합니다.
                // if(!this.state.isPanelOpen)
                //   this.handlePanelOpen();
에서 (e) => {}부분은 뷰어에서 어노테이션을 클릭했을 때 이벤트를 달아주는 방법입니다.

71 ~ 82-> ::selection은 드래그 했을 때의 색상 스타일 추가이고, 
.epubs-hl는 무슨 역할인지 아직 모르겠습니다.

90 ~ 106 -> 요청을 좀 더 안전한 방법으로 교체하였습니다. 


src/components/InfoPage/Info.jsx
7 -> let isUnmount = false; 
컴포넌트가 언마운트 되었음에도 불구하고 비동기적으로 setState()를 호출하게 되면, react에선 메모리누수(memory leak)이 발생합니다. 이것으 방지하기 위한 방법입니다.

13 ~ 26-> axios요청을 좀 더 안전한 방법으로 바꾸었습니다.

30~48 ->  쓸데 없는 코드를 수정했습니다.

src/components/ListPage/Book.js
처음에 public으로 요청할 수 있게 했습니다.

src/components/ListPage/DashBoard.css
"Renosh"에 약간의 css변경, 폰트 추가입니다.

src/components/PanelPage/AnnoBody.js
전체적으로  public과 private을 선택했을 때 의 변화를 담고 있습니다.

src/components/PanelPage/Panel.js
패널이 열릴때 해당 anno의 위치로 자동 스크롤 할 수 있는 테스트와 함수를 만들고 있었습니다.

src/components/PanelPage/SelectAnnoListArrange.css
src/components/PanelPage/SelectAnnoListArrange.jsx
패널에 annolist의 볼 수있는 범위 설정 관련("VIEW_MODE")수정사항입니다.

src/containers/PanelPage/AnnoBody.jsx
로그인 하지 않았을 경우의 검사문입니다.

src/containers/PanelPage/SelectAnnoListArrange.jsx
로그인 하지 않았을 경우의 검사문입니다.

src/store.js
패널에 annolist의 볼 수있는 범위 설정 관련("VIEW_MODE")수정사항입니다.