### PR TITLE
539/yoonjin/last read bug fix

### DIFF
--- a/src/components/EpubViewerPage/EpubViewer.js
+++ b/src/components/EpubViewerPage/EpubViewer.js
@@ -29,6 +29,8 @@ class EpubViewer extends Component {
       high_text: null,
       userid: this.props.userid,
       username: this.props.username,
+      lastRead:this.props.selected_lastRead,
+      userbooklistId: this.props.userbooklistId,
     };
     this.rendition = null;
   }
@@ -120,6 +122,10 @@ class EpubViewer extends Component {
     this.setState({ isPanelOpen: !this.state.isPanelOpen })
   };
 
+  setlastRead(epubcifi){
+    this.setState({lastRead:epubcifi});
+  }
+
   movePrev = () => {
     this.rendition.prev();
   }
@@ -131,6 +137,27 @@ class EpubViewer extends Component {
   changeLocation = (cfiRange) => {
     this.rendition.display(cfiRange);
   }
+
+  updateLastRead = async () =>{
+    await axios({
+      method:'put',
+      url: process.env.REACT_APP_RENOSH_BASE_URL + 'api/userbooklist/' + this.state.userid+'/'+this.state.userbooklistId+'/lastRead',
+      data:{
+          bookid:this.props.id,
+          location:this.state.lastRead
+      }
+    }).then(res=>{
+      this.props.updateMyLastRead('UPDATE_MY_BOOK_LIST', res.data.mybooklist);
+    })
+
+  }
+
+ componentWillUnmount(){    
+    if(this.state.userid!=='visitor'){
+      this.updateLastRead();
+    }
+ }
+
   deleteAllAnnoList(before_annoList) {  // 현재 그려진 모든 annoList를 지워주는 메소드
     for (let i = 0; i < before_annoList.length; i++) {
       let anno = before_annoList[i];
@@ -204,7 +231,7 @@ class EpubViewer extends Component {
                   url={this.props.epubURL}
                   title={this.props.title}
                   location={this.props.selected_cfiRange}
-                  // locationChanged={epubcifi => console.log(epubcifi)}
+                  locationChanged={epubcifi => this.setlastRead(epubcifi)}
                   getRendition={this.getRendition}
                 />
                 {this.state.isPanelOpen ? <Panel changeLocation={this.changeLocation} /> : ''}

--- a/src/components/PanelPage/AnnoBody.js
+++ b/src/components/PanelPage/AnnoBody.js
@@ -71,7 +71,7 @@ class AnnoBody extends Component {
         this.props.changeHighTextToNull("HIGHLIGHT_TO_NULL");
     }
     updateAnnoRequest(text, anno_id) {
-        document.getElementById('inputAnno').value = text;
+        document.getElementsByClassName('inputAnno').value = text;
         this.setState({
             high_id: anno_id
         })

--- a/src/containers/EpubViewerPage/EpubViewer.jsx
+++ b/src/containers/EpubViewerPage/EpubViewer.jsx
@@ -18,11 +18,23 @@ export default connect(
                 break;
             }
         }
-        selected_cfiRange = state.from_mypage ? state.selected_cfiRange : "2";
         userid = state.account ? state.account.accountIdentifier : 'visitor';
         username = state.account ? state.account.name : 'visitor';
         from_mypage = state.from_mypage;
         
+        let mybooklist, selected_lastRead="2";
+        let userbooklistId=null;
+        if(state.account){
+            mybooklist = state.myBookList;
+            for(let i=0;i<mybooklist.length;i++){
+                if(mybooklist[i].bookid===book_id){
+                    selected_lastRead = mybooklist[i].location;
+                }
+            }
+            userbooklistId = state.userBookList.id;
+        }
+        selected_cfiRange = state.from_mypage ? state.selected_cfiRange : selected_lastRead;
+
         return {
             id:book_id, 
             title, 
@@ -34,13 +46,18 @@ export default connect(
             userid,
             username,
             from_mypage,
-            view_type: state.annoList_view_type
+            view_type: state.annoList_view_type,
+            selected_lastRead,
+            userbooklistId
         }
     },
     function(dispatch) {
         return {
             updateAnnoList: function(mode, selected_high_id, selected_high_text){
                 dispatch({type: mode, selected_high_id, selected_high_text})
+            },
+            updateMyLastRead:function(mode,my_book_list){
+                dispatch({type:mode,my_book_list})
             }
         }
     }


### PR DESCRIPTION
- 이전에 읽던 위치를 저장하고 "뒤로가기" 눌렀을 때 userbooklist변수가 null로 되는 에러 수정 
    (이전에 읽던 위치를 저장한 후 state의 userBookList를 바꾸는 것이 아니라 myBookList를 바꿈)
 
- 이전에 읽던 위치가 제대로 저장되지 않고 + 또는 - 1 페이지로 저장되는 버그 수정
     (기존) lastRead = this.rendition.location.end;
     (수정) locationChanged={epubcifi => this.setlastRead(epubcifi)}  => 현재 읽고 있는 페이지의 값

- 배포된 master에서 annotation update가 안되는 에러 수정
![image](https://user-images.githubusercontent.com/37509450/92478367-08924b00-f21d-11ea-800f-502444c3ef84.png)

     메모를 입력하는 textarea 태그의 className이 inputAnno로 되어 있어서 
      (기존) document.getElementById('inputAnno').value = text;  
      (수정) document.getElementsByClassName('inputAnno').value = text;