### PR TITLE
559/taeeun/touch Apply a touch swipe(flip) event to a prev/next page on EpubViewerPage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12023,6 +12023,14 @@
         }
       }
     },
+    "react-swipe-component": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-swipe-component/-/react-swipe-component-3.0.0.tgz",
+      "integrity": "sha512-iE8qw7OHg2cMWmurWJC/EFj6LgB70AA+eRTbP4NZfdEF2qRVaC03cK2PxcfuB/lwz56slIntjFRwcYFAoYIrbQ==",
+      "requires": {
+        "react": "^16.8.1"
+      }
+    },
     "react-swipeable": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-5.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.3",
+    "react-swipe-component": "^3.0.0",
     "redux": "^4.0.5",
     "typescript": "^4.0.2"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -18,8 +18,7 @@ class App extends Component {
         <div className="App" onTouchStart={function(){
           if (!this.state.isTouched) {
             this.setState({isTouched : true});
-            store.dispatch({type : 'CHANGE_DEVICE', isTouched : true});
-            console.log("1. App 컴포넌트에 터치감지시작, store에 디스패치함");}
+            store.dispatch({type : 'CHANGE_DEVICE', isTouched : true});}
           }.bind(this)}>
           {/* <Link to="/"></Link><br/> */}
           <Switch>

--- a/src/App.js
+++ b/src/App.js
@@ -5,13 +5,16 @@ import BookListContentContainer from './containers/ListPage/BookListContent';
 import InfoContainer from './containers/InfoPage/Info';
 import EpubViewerContainer from './containers/EpubViewerPage/EpubViewer';
 import MyPageLayout from './components/MyPage/MyPageLayout';
+import store from './store';
 
 class App extends Component {
-
   render() {
     return (
       <BrowserRouter>
-        <div className="App">
+        <div className="App" onTouchStart={function(){
+          store.dispatch({type:'CHANGE_DEVICE', isTouched:true});
+          console.log("1. App 컴포넌트에 터치감지시작, store에 디스패치함");
+          }}>
           {/* <Link to="/"></Link><br/> */}
           <Switch>
             <Route exact path="/" component={BookListContentContainer} ></Route>            

--- a/src/App.js
+++ b/src/App.js
@@ -8,13 +8,19 @@ import MyPageLayout from './components/MyPage/MyPageLayout';
 import store from './store';
 
 class App extends Component {
+  state = {
+    isTouched : false
+  }
+
   render() {
     return (
       <BrowserRouter>
         <div className="App" onTouchStart={function(){
-          store.dispatch({type:'CHANGE_DEVICE', isTouched:true});
-          console.log("1. App 컴포넌트에 터치감지시작, store에 디스패치함");
-          }}>
+          if (!this.state.isTouched) {
+            this.setState({isTouched : true});
+            store.dispatch({type : 'CHANGE_DEVICE', isTouched : true});
+            console.log("1. App 컴포넌트에 터치감지시작, store에 디스패치함");}
+          }.bind(this)}>
           {/* <Link to="/"></Link><br/> */}
           <Switch>
             <Route exact path="/" component={BookListContentContainer} ></Route>            

--- a/src/components/EpubViewerPage/EpubViewer.js
+++ b/src/components/EpubViewerPage/EpubViewer.js
@@ -3,6 +3,7 @@ import { Swipe } from "react-swipe-component";
 import Panel from '../PanelPage/Panel';
 import { Link } from 'react-router-dom';
 import axios from "axios";
+import { Helmet } from "react-helmet";
 import {
   EpubView, // Underlaying epub-canvas (wrapper for epub.js iframe)
   // EpubViewStyle, // Styles for EpubView, you can pass it to the instance as a style prop for customize it
@@ -20,6 +21,7 @@ class EpubViewer extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      touchDevice: this.props.touchDevice,
       fullscreen: false,
       location: 2,
       localFile: null,
@@ -246,6 +248,7 @@ class EpubViewer extends Component {
     return true;
   }
 
+  // Swipe 함수
   onSwipeEnd = () => {
     console.log("Swipe Ended")
   }
@@ -257,7 +260,7 @@ class EpubViewer extends Component {
   onSwipeRightListener = () => {
     console.log("Swiped right");
     document.getElementById("demo").innerHTML = "Right";
-    this.moveNext()
+    this.moveNext();
   }
   onSwipeListener = (p) => {
     if (p.x !== 0) {
@@ -267,17 +270,51 @@ class EpubViewer extends Component {
       console.log(`Swipe y: ${p.y}`)
     }
   }
+  onSwipeEnd = () => {
+    console.log("Swipe Ended")
+  }
+
+  iframeMove() {
+    if (document.getElementsByTagName("iframe")[0] && this.state.touchDevice) {
+      let iframe = document.getElementsByTagName("iframe")[0];
+      // 만약 state에 touchDevice 여부가 true라면 iframe에 className을 주입해서 마우스 이벤트를 막는다.
+      iframe.className = "mobile";
+      console.log("5. touchDevice 여부에 따라 iframe의 className을 mobile로 변경한다.");
+      console.log(iframe.className);
+    }
+  }
+
+  componentDidMount() {
+    // 현재 epub 파일을 로딩해서 컴포넌트로 받아오는데 평균 최소 1초는 걸린다. (크기, 상황에 따라 다르겠지만)
+    setTimeout(() => {
+      let iframe = document.getElementsByTagName("iframe")[0];
+      if (iframe) {
+        console.log("3. iframe 렌더링 확인됨.");
+      }
+      if (this.state.touchDevice) {
+        console.log("4. redux의 state에서 touchDevice 여부 가져오기 성공.");
+        // 만약 state에 touchDevice 여부가 true라면 iframe에 className을 주입해서 마우스 이벤트를 막는다.
+        iframe.className = "mobile";
+        console.log("5. touchDevice 여부에 따라 iframe의 className을 mobile로 변경한다.");
+        console.log(iframe.className);
+      }
+    }, 2000);
+  }
+
+  componentWillUpdate() {
+    let iframe = document.getElementsByTagName("iframe")[0];
+    if (this.state.touchDevice) {
+      iframe.className = "mobile";
+      console.log("componentWillUpdate");
+    }
+  }
 
   componentDidUpdate() {
     let iframe = document.getElementsByTagName("iframe")[0];
-    // widthSize = window.innerWidth;  할당이 안됨
-    if (window.innerWidth < 576) {
+    if (this.state.touchDevice) {
       iframe.className = "mobile";
+      console.log("componentDidUpdate");
     }
-    else {
-      iframe.className = "desktop";
-    }
-    console.log(iframe.className);
   }
 
   render() {
@@ -287,7 +324,8 @@ class EpubViewer extends Component {
       onSwipedLeft={this.onSwipeLeftListener}
       onSwipedRight={this.onSwipeRightListener}
       onSwipe={this.onSwipeListener}
-      detectTouch="true">
+      /*--아래사항은 touchDevice 여부에 따라 설정하게 변경하기--*/
+      detectMouse="false" detectTouch="true">
         <Layout className="epubViewerPageLayout">
           <Header>
             <section>
@@ -304,7 +342,7 @@ class EpubViewer extends Component {
                   <EditOutlined />
                 </Button>
               </h1>
-              <h1 id="demo"></h1>
+              <h1 id="demo"> </h1>
             </section>
           </Header>
 
@@ -333,8 +371,9 @@ class EpubViewer extends Component {
             </Content>
             <Sider><Button onClick={() => this.moveNext()}><RightOutlined /></Button></Sider>
           </Layout>
-
+          
         </Layout>
+        <Helmet><script>{this.iframeMove()}</script></Helmet>
       </Swipe>
     );
   }

--- a/src/components/EpubViewerPage/EpubViewer.js
+++ b/src/components/EpubViewerPage/EpubViewer.js
@@ -3,7 +3,6 @@ import { Swipe } from "react-swipe-component";
 import Panel from '../PanelPage/Panel';
 import { Link } from 'react-router-dom';
 import axios from "axios";
-import { Helmet } from "react-helmet";
 import {
   EpubView, // Underlaying epub-canvas (wrapper for epub.js iframe)
   // EpubViewStyle, // Styles for EpubView, you can pass it to the instance as a style prop for customize it
@@ -38,7 +37,6 @@ class EpubViewer extends Component {
     };
     this.rendition = null;
   }
-
   // getAnnoData = async () => {
   //     let book_id = this.props.id;
   //     const annos = await axios.get(process.env.REACT_APP_RENOSH_BASE_URL+"api/highlights/book/" + book_id+ "/public");
@@ -274,16 +272,6 @@ class EpubViewer extends Component {
     console.log("Swipe Ended")
   }
 
-  iframeMove() {
-    if (document.getElementsByTagName("iframe")[0] && this.state.touchDevice) {
-      let iframe = document.getElementsByTagName("iframe")[0];
-      // 만약 state에 touchDevice 여부가 true라면 iframe에 className을 주입해서 마우스 이벤트를 막는다.
-      iframe.className = "mobile";
-      console.log("5. touchDevice 여부에 따라 iframe의 className을 mobile로 변경한다.");
-      console.log(iframe.className);
-    }
-  }
-
   componentDidMount() {
     // 현재 epub 파일을 로딩해서 컴포넌트로 받아오는데 평균 최소 1초는 걸린다. (크기, 상황에 따라 다르겠지만)
     setTimeout(() => {
@@ -291,7 +279,7 @@ class EpubViewer extends Component {
       if (iframe) {
         console.log("3. iframe 렌더링 확인됨.");
       }
-      if (this.state.touchDevice) {
+      if (this.state.touchDevice === true) {
         console.log("4. redux의 state에서 touchDevice 여부 가져오기 성공.");
         // 만약 state에 touchDevice 여부가 true라면 iframe에 className을 주입해서 마우스 이벤트를 막는다.
         iframe.className = "mobile";
@@ -300,10 +288,10 @@ class EpubViewer extends Component {
       }
     }, 2000);
   }
-
+  
   componentWillUpdate() {
     let iframe = document.getElementsByTagName("iframe")[0];
-    if (this.state.touchDevice) {
+    if (this.state.touchDevice === true) {
       iframe.className = "mobile";
       console.log("componentWillUpdate");
     }
@@ -311,7 +299,7 @@ class EpubViewer extends Component {
 
   componentDidUpdate() {
     let iframe = document.getElementsByTagName("iframe")[0];
-    if (this.state.touchDevice) {
+    if (this.state.touchDevice === true) {
       iframe.className = "mobile";
       console.log("componentDidUpdate");
     }
@@ -319,13 +307,7 @@ class EpubViewer extends Component {
 
   render() {
     return (
-      <Swipe className="epubViewerPageContainer"
-      onSwipeEnd={this.onSwipeEnd}
-      onSwipedLeft={this.onSwipeLeftListener}
-      onSwipedRight={this.onSwipeRightListener}
-      onSwipe={this.onSwipeListener}
-      /*--아래사항은 touchDevice 여부에 따라 설정하게 변경하기--*/
-      detectMouse="false" detectTouch="true">
+      <div className="epubViewerPageContainer">
         <Layout className="epubViewerPageLayout">
           <Header>
             <section>
@@ -348,33 +330,37 @@ class EpubViewer extends Component {
 
           <Layout id="epubViewerPageBody">
             <Sider><Button onClick={() => this.movePrev()}><LeftOutlined /></Button></Sider>
-            <Content>
-              <div id="epubViewer">
-                <EpubView
-                  url={this.props.epubURL}
-                  title={this.props.title}
-                  location={this.props.selected_cfiRange}
-                  locationChanged={epubcifi => this.setlastRead(epubcifi)}
-                  getRendition={this.getRendition}
-                />
-                {<Panel
-                  changeLocation={this.changeLocation}
-                  visible={this.state.isPanelOpen}
-                  handlePanelOpen={this.handlePanelOpen}
-                  high_id={this.state.high_id}
-                  high_text={this.state.high_text}
-                  deleteHigh={this.deleteHigh}
-                  dragged_anno_id={this.state.dragged_anno_id}
-                  zIndex={5000}
-                />}
-              </div>
+            <Content id = "epubViewer">
+              <Swipe style={{position:"relative", height:"100%", width:"100%"}}
+                onSwipeEnd={this.onSwipeEnd}
+                onSwipedLeft={this.onSwipeLeftListener}
+                onSwipedRight={this.onSwipeRightListener}
+                onSwipe={this.onSwipeListener}
+                detectMouse="false" detectTouch="true"
+               >
+                  <EpubView
+                    url={this.props.epubURL}
+                    title={this.props.title}
+                    location={this.props.selected_cfiRange}
+                    locationChanged={epubcifi => this.setlastRead(epubcifi)}
+                    getRendition={this.getRendition}
+                  />
+                  {<Panel
+                    changeLocation={this.changeLocation}
+                    visible={this.state.isPanelOpen}
+                    handlePanelOpen={this.handlePanelOpen}
+                    high_id={this.state.high_id}
+                    high_text={this.state.high_text}
+                    deleteHigh={this.deleteHigh}
+                    dragged_anno_id={this.state.dragged_anno_id}
+                    zIndex={5000}
+                  />}
+              </Swipe>
             </Content>
             <Sider><Button onClick={() => this.moveNext()}><RightOutlined /></Button></Sider>
           </Layout>
-          
         </Layout>
-        <Helmet><script>{this.iframeMove()}</script></Helmet>
-      </Swipe>
+      </div>
     );
   }
 }

--- a/src/components/EpubViewerPage/EpubViewer.js
+++ b/src/components/EpubViewerPage/EpubViewer.js
@@ -250,16 +250,14 @@ class EpubViewer extends Component {
     console.log("Swipe Ended")
   }
   onSwipeLeftListener = () => {
-    console.log("Swiped left")
+    console.log("Swiped left");
+    document.getElementById("demo").innerHTML = "Left";
+    this.movePrev();
   }
   onSwipeRightListener = () => {
-    console.log("Swiped right")
-  }
-  onSwipeUpListener = () => {
-    console.log("Swiped Up")
-  }
-  onSwipeDownListener = () => {
-    console.log("Swiped down")
+    console.log("Swiped right");
+    document.getElementById("demo").innerHTML = "Right";
+    this.moveNext()
   }
   onSwipeListener = (p) => {
     if (p.x !== 0) {
@@ -270,14 +268,26 @@ class EpubViewer extends Component {
     }
   }
 
+  componentDidUpdate() {
+    let iframe = document.getElementsByTagName("iframe")[0];
+    // widthSize = window.innerWidth;  할당이 안됨
+    if (window.innerWidth < 576) {
+      iframe.className = "mobile";
+    }
+    else {
+      iframe.className = "desktop";
+    }
+    console.log(iframe.className);
+  }
+
   render() {
     return (
       <Swipe className="epubViewerPageContainer"
-      detectTouch="true"
       onSwipeEnd={this.onSwipeEnd}
       onSwipedLeft={this.onSwipeLeftListener}
       onSwipedRight={this.onSwipeRightListener}
-      onSwipe={this.onSwipeListener}>
+      onSwipe={this.onSwipeListener}
+      detectTouch="true">
         <Layout className="epubViewerPageLayout">
           <Header>
             <section>
@@ -294,6 +304,7 @@ class EpubViewer extends Component {
                   <EditOutlined />
                 </Button>
               </h1>
+              <h1 id="demo"></h1>
             </section>
           </Header>
 

--- a/src/components/EpubViewerPage/EpubViewer.js
+++ b/src/components/EpubViewerPage/EpubViewer.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { Swipe } from "react-swipe-component";
 import Panel from '../PanelPage/Panel';
 import { Link } from 'react-router-dom';
 import axios from "axios";
@@ -244,9 +245,39 @@ class EpubViewer extends Component {
     }
     return true;
   }
+
+  onSwipeEnd = () => {
+    console.log("Swipe Ended")
+  }
+  onSwipeLeftListener = () => {
+    console.log("Swiped left")
+  }
+  onSwipeRightListener = () => {
+    console.log("Swiped right")
+  }
+  onSwipeUpListener = () => {
+    console.log("Swiped Up")
+  }
+  onSwipeDownListener = () => {
+    console.log("Swiped down")
+  }
+  onSwipeListener = (p) => {
+    if (p.x !== 0) {
+      console.log(`Swipe x: ${p.x}`)
+    }
+    if (p.y !== 0) {
+      console.log(`Swipe y: ${p.y}`)
+    }
+  }
+
   render() {
     return (
-      <div className="epubViewerPageContainer">
+      <Swipe className="epubViewerPageContainer"
+      detectTouch="true"
+      onSwipeEnd={this.onSwipeEnd}
+      onSwipedLeft={this.onSwipeLeftListener}
+      onSwipedRight={this.onSwipeRightListener}
+      onSwipe={this.onSwipeListener}>
         <Layout className="epubViewerPageLayout">
           <Header>
             <section>
@@ -293,7 +324,7 @@ class EpubViewer extends Component {
           </Layout>
 
         </Layout>
-      </div>
+      </Swipe>
     );
   }
 }

--- a/src/components/EpubViewerPage/EpubViewer.js
+++ b/src/components/EpubViewerPage/EpubViewer.js
@@ -235,14 +235,40 @@ class EpubViewer extends Component {
       }
     }
   }
+  componentDidMount() {
+    // 현재 epub 파일을 로딩해서 컴포넌트로 받아오는데 평균 최소 1초는 걸린다. (크기, 상황에 따라 다르겠지만)
+    setTimeout(() => {
+      let iframe = document.getElementsByTagName("iframe")[0];
+      if (iframe && (this.state.touchDevice === true)) {
+        // 만약 state에 touchDevice 여부가 true라면 iframe에 className을 주입해서 마우스 이벤트를 막는다.
+        iframe.className = "mobile";
+      }
+      else {
+        alert("페이지 로딩에 실패했습니다.");
+      }
+    }, 2000);
+  }
+
   shouldComponentUpdate(nextProps, nextState) {
     if (JSON.stringify(this.props.annoList) !== JSON.stringify(nextProps.annoList)) {
       this.deleteAllAnnoList(this.props.annoList);
       this.drawAllAnnoList(nextProps.view_type, nextProps.annoList)
     }
-    return true;
+    // touch action을 위한 iframe className 조작
+    let iframe = document.getElementsByTagName("iframe")[0];
+    if (this.state.touchDevice === true) {
+      iframe.className = "mobile";
+    }
+    return true; // false를 반환하면 render()는 호출되지 않는다.
   }
 
+  componentDidUpdate() {
+    let iframe = document.getElementsByTagName("iframe")[0];
+    if (this.state.touchDevice === true) {
+      iframe.className = "mobile";
+    }
+  }
+  
   // Swipe 함수
   onSwipeLeftListener = () => {
     this.movePrev();
@@ -260,35 +286,6 @@ class EpubViewer extends Component {
     }
   }
   */
-
-  componentDidMount() {
-    // 현재 epub 파일을 로딩해서 컴포넌트로 받아오는데 평균 최소 1초는 걸린다. (크기, 상황에 따라 다르겠지만)
-    setTimeout(() => {
-      let iframe = document.getElementsByTagName("iframe")[0];
-      if (iframe && (this.state.touchDevice === true)) {
-        // 만약 state에 touchDevice 여부가 true라면 iframe에 className을 주입해서 마우스 이벤트를 막는다.
-        iframe.className = "mobile";
-      }
-      else {
-        alert("페이지 로딩에 실패했습니다.");
-      }
-    }, 2000);
-  }
-
-  shouldComponentUpdate() {
-    let iframe = document.getElementsByTagName("iframe")[0];
-    if (this.state.touchDevice === true) {
-      iframe.className = "mobile";
-    }
-    return false; // shouldComponentUpdate()가 false를 반환하면 render()는 호출되지 않는다.
-  }
-
-  componentDidUpdate() {
-    let iframe = document.getElementsByTagName("iframe")[0];
-    if (this.state.touchDevice === true) {
-      iframe.className = "mobile";
-    }
-  }
 
   render() {
     return (

--- a/src/components/EpubViewerPage/EpubViewer.js
+++ b/src/components/EpubViewerPage/EpubViewer.js
@@ -275,11 +275,12 @@ class EpubViewer extends Component {
     }, 2000);
   }
 
-  componentWillUpdate() {
+  shouldComponentUpdate() {
     let iframe = document.getElementsByTagName("iframe")[0];
     if (this.state.touchDevice === true) {
       iframe.className = "mobile";
     }
+    return false; // shouldComponentUpdate()가 false를 반환하면 render()는 호출되지 않는다.
   }
 
   componentDidUpdate() {
@@ -317,7 +318,7 @@ class EpubViewer extends Component {
             <Content id = "epubViewer">
               <Swipe style={{position:"relative", height:"100%", width:"100%"}}
                 onSwipedLeft={this.onSwipeLeftListener}
-                onSwipedRight={this.onSwipeRightListener}
+                onSwipedRight={this.onSwipeRightListener}q
                 detectMouse="false" detectTouch="true"
                >
                   <EpubView

--- a/src/components/EpubViewerPage/EpubViewer.js
+++ b/src/components/EpubViewerPage/EpubViewer.js
@@ -79,8 +79,6 @@ class EpubViewer extends Component {
       }
     }
 
-
-
     // 새로 highlight를 만들 때 이용하는 메서드 입니다.
     this.rendition.on("selected", function (cfiRange, contents) {
       rendition.annotations.add("highlight", cfiRange, {}, (e) => {
@@ -134,7 +132,6 @@ class EpubViewer extends Component {
     }.bind(this));
   };
 
-  // handlePanelOpen 함수에 .bind(this) 추가했다. = () => 최신문법으로. 
   handlePanelOpen = () => {
     if (this.state.isPanelOpen) {
       this.deleteHigh();
@@ -247,19 +244,13 @@ class EpubViewer extends Component {
   }
 
   // Swipe 함수
-  onSwipeEnd = () => {
-    console.log("Swipe Ended")
-  }
   onSwipeLeftListener = () => {
-    console.log("Swiped left");
-    document.getElementById("demo").innerHTML = "Left";
     this.movePrev();
   }
   onSwipeRightListener = () => {
-    console.log("Swiped right");
-    document.getElementById("demo").innerHTML = "Right";
     this.moveNext();
   }
+  /*
   onSwipeListener = (p) => {
     if (p.x !== 0) {
       console.log(`Swipe x: ${p.x}`)
@@ -268,32 +259,26 @@ class EpubViewer extends Component {
       console.log(`Swipe y: ${p.y}`)
     }
   }
-  onSwipeEnd = () => {
-    console.log("Swipe Ended")
-  }
+  */
 
   componentDidMount() {
     // 현재 epub 파일을 로딩해서 컴포넌트로 받아오는데 평균 최소 1초는 걸린다. (크기, 상황에 따라 다르겠지만)
     setTimeout(() => {
       let iframe = document.getElementsByTagName("iframe")[0];
-      if (iframe) {
-        console.log("3. iframe 렌더링 확인됨.");
-      }
-      if (this.state.touchDevice === true) {
-        console.log("4. redux의 state에서 touchDevice 여부 가져오기 성공.");
+      if (iframe && (this.state.touchDevice === true)) {
         // 만약 state에 touchDevice 여부가 true라면 iframe에 className을 주입해서 마우스 이벤트를 막는다.
         iframe.className = "mobile";
-        console.log("5. touchDevice 여부에 따라 iframe의 className을 mobile로 변경한다.");
-        console.log(iframe.className);
+      }
+      else {
+        alert("페이지 로딩에 실패했습니다.");
       }
     }, 2000);
   }
-  
+
   componentWillUpdate() {
     let iframe = document.getElementsByTagName("iframe")[0];
     if (this.state.touchDevice === true) {
       iframe.className = "mobile";
-      console.log("componentWillUpdate");
     }
   }
 
@@ -301,7 +286,6 @@ class EpubViewer extends Component {
     let iframe = document.getElementsByTagName("iframe")[0];
     if (this.state.touchDevice === true) {
       iframe.className = "mobile";
-      console.log("componentDidUpdate");
     }
   }
 
@@ -332,10 +316,8 @@ class EpubViewer extends Component {
             <Sider><Button onClick={() => this.movePrev()}><LeftOutlined /></Button></Sider>
             <Content id = "epubViewer">
               <Swipe style={{position:"relative", height:"100%", width:"100%"}}
-                onSwipeEnd={this.onSwipeEnd}
                 onSwipedLeft={this.onSwipeLeftListener}
                 onSwipedRight={this.onSwipeRightListener}
-                onSwipe={this.onSwipeListener}
                 detectMouse="false" detectTouch="true"
                >
                   <EpubView

--- a/src/components/EpubViewerPage/EpubViewer.js
+++ b/src/components/EpubViewerPage/EpubViewer.js
@@ -318,7 +318,7 @@ class EpubViewer extends Component {
             <Content id = "epubViewer">
               <Swipe style={{position:"relative", height:"100%", width:"100%"}}
                 onSwipedLeft={this.onSwipeLeftListener}
-                onSwipedRight={this.onSwipeRightListener}q
+                onSwipedRight={this.onSwipeRightListener}
                 detectMouse="false" detectTouch="true"
                >
                   <EpubView

--- a/src/components/EpubViewerPage/epubViewer.less
+++ b/src/components/EpubViewerPage/epubViewer.less
@@ -1,5 +1,6 @@
-iframe, .desktop {
-    pointer-events: all;
+iframe.mobile {
+    pointer-events: none;
+    touch-action: auto;
 }
 
 .epubViewerPageContainer{
@@ -129,11 +130,6 @@ iframe, .desktop {
 }
 
 @media only screen and (max-width: 576px) {
-    iframe, .mobile {
-        pointer-events: none;
-        touch-action: auto;
-    }
-
     .epubViewerPageContainer{
         .epubViewerPageLayout { 
             #epubViewerPageBody {

--- a/src/components/EpubViewerPage/epubViewer.less
+++ b/src/components/EpubViewerPage/epubViewer.less
@@ -1,3 +1,7 @@
+iframe, .desktop {
+    pointer-events: all;
+}
+
 .epubViewerPageContainer{
     .epubViewerPageLayout {
         .ant-layout-header {
@@ -125,6 +129,11 @@
 }
 
 @media only screen and (max-width: 576px) {
+    iframe, .mobile {
+        pointer-events: none;
+        touch-action: auto;
+    }
+
     .epubViewerPageContainer{
         .epubViewerPageLayout { 
             #epubViewerPageBody {

--- a/src/containers/EpubViewerPage/EpubViewer.jsx
+++ b/src/containers/EpubViewerPage/EpubViewer.jsx
@@ -3,6 +3,7 @@ import EpubViewer from "../../components/EpubViewerPage/EpubViewer";
 
 export default connect(
     function(state) {
+        let touchDevice = state.touchDevice;
         let book_id = state.selected_book_id, selected_cfiRange, from_mypage;
         let title, image, summary, author, epubURL;
         let userid, username;
@@ -36,6 +37,7 @@ export default connect(
         selected_cfiRange = state.from_mypage ? state.selected_cfiRange : selected_lastRead;
 
         return {
+            touchDevice,
             id:book_id, 
             title, 
             image, 

--- a/src/store.js
+++ b/src/store.js
@@ -41,6 +41,10 @@ const deepCopyFunction = (inObject) => {
   }
 
 var initState = {
+    // Touch Event Related states
+    touchDevice: false,
+
+    // Book Related states
     books: [],
     userBookList: [],
     myBookList: [],
@@ -62,6 +66,9 @@ var initState = {
 
 function reducer(state = initState, action) {
     switch (action.type) {
+        case 'CHANGE_DEVICE':
+            console.log("2. store에서 디스패치된 액션을 인지함. store의 state를 디스패치된 값으로 바꿈.");
+            return { ...state, touchDevice: action.isTouched };
         case 'INIT_BOOKS':
             var newBooks = action.books;
             return { ...state, books: newBooks };

--- a/src/store.js
+++ b/src/store.js
@@ -9,7 +9,6 @@ function saveToLocalStorage(state) {
         console.log(e)
     }
 }
-
 function loadFromLocalStorage() {
     try {
         const serializedState = localStorage.getItem('state');
@@ -67,7 +66,6 @@ var initState = {
 function reducer(state = initState, action) {
     switch (action.type) {
         case 'CHANGE_DEVICE':
-            console.log("2. store에서 디스패치된 액션을 인지함. store의 state를 디스패치된 값으로 바꿈.");
             return { ...state, touchDevice: action.isTouched };
         case 'INIT_BOOKS':
             var newBooks = action.books;


### PR DESCRIPTION
### Apply a swipe(flip) event to a prev/next page on EpubViewerPage
이전에 미팅에서 말씀드렸던 방안으로 터치 이벤트를 구현했습니다.

일단 futurepress/epub.js 레포의 issue에 남아있던 해결방안이 정석인 것 같아 보였습니다.

그러나 현재 그 방식을 시도해보는데 시간이 조금 걸릴 것 같고 현재 시간적 여유가 너무 없어서ㅠㅠ 보류하는 것으로 결정했습니다.
일단 리소스를 적어두고 종강을 하고서야 시도해볼 수 있을 것 같습니다. 
- **futurepress/epub.js 레포의 touch issue** : https://github.com/futurepress/epub.js/issues/510
- **관련 내용의 블로그** : https://lapizdigi.wordpress.com/tag/epub-js/
- **hook register** : http://epubjs.org/documentation/0.3/#hookregister

본 PR에서는 EpubViewer.js에서 쓸데없는 함수를 없애거나 다듬었고, App.js에서 dispatch하는 것도 state에 참/거짓 정보를 저장하여 한번 참으로 바뀌었으면 더이상 dispatch하지 않게 수정했습니다.

또한 종호님의 제안대로 ComponentWillUpdate도 shouldComponentUpdate로 변경하였습니다.