### PR TITLE
Change the if else condition for alert (Bug fix)

### DIFF
--- a/src/components/EpubViewerPage/EpubViewer.js
+++ b/src/components/EpubViewerPage/EpubViewer.js
@@ -243,8 +243,8 @@ class EpubViewer extends Component {
         // 만약 state에 touchDevice 여부가 true라면 iframe에 className을 주입해서 마우스 이벤트를 막는다.
         iframe.className = "mobile";
       }
-      else {
-        alert("페이지 로딩에 실패했습니다.");
+      else if (!iframe && (this.state.touchDevice === true)) {
+        alert("모바일 페이지 로딩에 실패했습니다.");
       }
     }, 2000);
   }


### PR DESCRIPTION
모바일에서 iframe 태그를 잡아오지 못하면 경고창을 띄웠는데, 조건문을 잘못 작성해서 데스크탑에서는 디폴트로 떴네요. 수정합니다.